### PR TITLE
Update QuickEntryViewController.swift

### DIFF
--- a/doordeck-sdk-swift/Quick Entry/QuickEntryViewController.swift
+++ b/doordeck-sdk-swift/Quick Entry/QuickEntryViewController.swift
@@ -55,7 +55,7 @@ class QuickEntryViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()    
-        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
     
     @objc func appWillResignActive(_ notification: Notification) {


### PR DESCRIPTION
Only when it comes to foreground (because it should have been in background)